### PR TITLE
Thread 미션

### DIFF
--- a/thread/src/main/resources/application.yml
+++ b/thread/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 server:
   tomcat:
     accept-count: 1
-    max-connections: 1
+    max-connections: 10
     threads:
       max: 2

--- a/thread/src/test/java/concurrency/stage0/SynchronizationTest.java
+++ b/thread/src/test/java/concurrency/stage0/SynchronizationTest.java
@@ -1,12 +1,11 @@
 package concurrency.stage0;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 /**
  * 다중 스레드 환경에서 두 개 이상의 스레드가 변경 가능한(mutable) 공유 데이터를 동시에 업데이트하면 경쟁 조건(race condition)이 발생한다.
@@ -41,7 +40,7 @@ class SynchronizationTest {
 
         private int sum = 0;
 
-        public void calculate() {
+        public synchronized void calculate() {
             setSum(getSum() + 1);
         }
 
@@ -49,7 +48,7 @@ class SynchronizationTest {
             return sum;
         }
 
-        public void setSum(int sum) {
+        public synchronized void setSum(int sum) {
             this.sum = sum;
         }
     }

--- a/thread/src/test/java/concurrency/stage0/ThreadPoolsTest.java
+++ b/thread/src/test/java/concurrency/stage0/ThreadPoolsTest.java
@@ -1,13 +1,12 @@
 package concurrency.stage0;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * 스레드 풀은 무엇이고 어떻게 동작할까?
@@ -31,8 +30,8 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello fixed thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
-        final int expectedQueueSize = 0;
+        final int expectedPoolSize = 2;
+        final int expectedQueueSize = 1;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());
         assertThat(expectedQueueSize).isEqualTo(executor.getQueue().size());
@@ -46,7 +45,7 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello cached thread pools"));
 
         // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
+        final int expectedPoolSize = 3;
         final int expectedQueueSize = 0;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());

--- a/thread/src/test/java/concurrency/stage1/UserServlet.java
+++ b/thread/src/test/java/concurrency/stage1/UserServlet.java
@@ -11,7 +11,7 @@ public class UserServlet {
         join(user);
     }
 
-    private void join(final User user) {
+    synchronized private void join(final User user) {
         if (!users.contains(user)) {
             users.add(user);
         }

--- a/thread/src/test/java/concurrency/stage2/AppTest.java
+++ b/thread/src/test/java/concurrency/stage2/AppTest.java
@@ -1,11 +1,10 @@
 package concurrency.stage2;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.http.HttpResponse;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class AppTest {
 
@@ -32,7 +31,7 @@ class AppTest {
 
         for (final var thread : threads) {
             thread.start();
-            Thread.sleep(50);
+            Thread.sleep(10);
         }
 
         for (final var thread : threads) {


### PR DESCRIPTION
# Thread 미션

## 학습 도움 자료

- [https://www.codelatte.io/courses/java_programming_basic/7S5AANE0DS9VHQR8](https://www.codelatte.io/courses/java_programming_basic/7S5AANE0DS9VHQR8)
- [https://docs.oracle.com/javase/tutorial/essential/concurrency/pools.html](https://docs.oracle.com/javase/tutorial/essential/concurrency/pools.html)
- [https://www.baeldung.com/thread-pool-java-and-guava](https://www.baeldung.com/thread-pool-java-and-guava)

### 쓰레드 풀?

- 이 뭔가
- 왜 필요한가

### 쓰레드 풀의 Queue?

- 쓰레드에 들어가기 전 대기줄

## Stage1 - 특정 상황에서 동시성문제 발생

```java
package concurrency.stage1;

import org.junit.jupiter.api.Test;

import static org.assertj.core.api.Assertions.assertThat;

/**
 * 스레드를 다룰 때 어떤 상황을 조심해야 할까?
 * - 상태를 가진 한 객체를 여러 스레드에서 동시에 접근할 경우
 * - static 변수를 가진 객체를 여러 스레드에서 동시에 접근할 경우
 *
 * 위 경우는 동기화(synchronization)를 적용시키거나 객체가 상태를 갖지 않도록 한다.
 * 객체를 불변 객체로 만드는 방법도 있다.
 *
 * 웹서버는 여러 사용자가 동시에 접속을 시도하기 때문에 동시성 이슈가 생길 수 있다.
 * 어떤 사례가 있는지 아래 테스트 코드를 통해 알아보자.
 */
class ConcurrencyTest {

    @Test
    void test() throws InterruptedException {
        final var userServlet = new UserServlet();

        // 웹서버로 동시에 2명의 유저가 gugu라는 이름으로 가입을 시도했다.
        // UserServlet의 users에 이미 가입된 회원이 있으면 중복 가입할 수 없도록 코드를 작성했다.
        final var firstThread = new Thread(new HttpProcessor(new User("gugu"), userServlet));
        final var secondThread = new Thread(new HttpProcessor(new User("gugu"), userServlet));

        // 스레드는 실행 순서가 정해져 있지 않다.
        // firstThread보다 늦게 시작한 secondThread가 먼저 실행될 수도 있다.
        firstThread.start();
        secondThread.start();
        secondThread.join(); // secondThread가 먼저 gugu로 가입했다.
        firstThread.join();

        // 이미 gugu로 가입한 사용자가 있어서 UserServlet.join() 메서드의 if절 조건은 false가 되고 크기는 1이다.
        // 하지만 디버거로 개별 스레드를 일시 중지하면 if절 조건이 true가 되고 크기가 2가 된다. 왜 그럴까?
        assertThat(userServlet.getUsers()).hasSize(1);
    }
}
```

그냥 돌리면 통과하지만 add하는 부분에서 중단점을 걸면 동시성 문제가 발생한다.

```java
package concurrency.stage1;

import java.util.ArrayList;
import java.util.List;

public class UserServlet {

    private final List<User> users = new ArrayList<>();

    public void service(final User user) {
        join(user);
    }

    private void join(final User user) {
        if (!users.contains(user)) {
            users.add(user); // 이 부분의 쓰레드 중단점 걸기
        }
    }

    public int size() {
        return users.size();
    }

    public List<User> getUsers() {
        return users;
    }
}
```

### 예상

- 쓰레드 별로 중단점을 걸기때문에 (A 쓰레드, B 쓰레드 이렇게 두개 존재한다.)
    - A쓰레드의 첫 if문이 통과하고 중단을 걸면, 아직은 add가 안되어있다.
    - 그런데 B쓰레드는 중단을 걸지 않았기 때문에 계속 돌고있고 add를 한다.
    - 그 다음 A 쓰레드가 add를 하면 정상적으로 등록된다.
- 예상 적중한거같음

### 해결방법

- 해당 if 문을 포함하는 메서드가 동작할때 그 메서드의 `synchronized` 를 걸어준다.
- 그러면 중단점이 걸려있어도 다른 쓰레드에서 이 메서드에 접근하지 못한다.

## Stage2 - 멀티 쓰레드의 http 요청

학습 참고자료 : [https://tomcat.apache.org/tomcat-8.0-doc/config/http.html](https://tomcat.apache.org/tomcat-8.0-doc/config/http.html)

어플리케이션

- 톰캣 상황:

```java
server:
  tomcat:
    accept-count: 1
    max-connections: 1
    threads:
      max: 2
```

각 설정의 의미

- **`accep-count`** : 커넥터가 생성한 서버 소켓 내부의 최대값
    - 쓰레드가 꽉찼는데도 여전히 동시요청이 올 경우 커넥터가 생성한 서버 소켓 내부(acceptCount 값 까지)에 쌓인다.
- `**max-connections**` : 서버가 주어진 시간안에 처리를 허용할 최대 연결 수
    - 서버에 연결된 커넥션이 최대에 도달하면 딱 하나의 연결을 추가하고 처리하지는 않는다.
    - max-connections 아래로 떨어지는 순간 연결된 하나의 커넥션 수행
    - BIO 에서는 maxThread 개수만큼
    - NIO 에서는 10000
- `**threads_max**`: 톰캣에서 사용하는 쓰레드의 최대 개수
    - 톰캣은 각 요청당 쓰레드 하나가 필요하다.
    - 만약 동시요청이 올 경우 max-thread 설정 개수까지 쓰레드가 늘어난다

테스트코드

- 10개의 쓰레드가 http 요청 동시요청을 보낸다.
    - 그래도 각 요청마다 0.05초의 텀은 있다.
- 요청의 응답이 200이면 count를 증가시킨다.
- count가 2여야 한다.

동기 vs 비동기

…