### PR TITLE
Tranaction 실습

### DIFF
--- a/transaction/src/test/java/transaction/stage0/Stage0Test.java
+++ b/transaction/src/test/java/transaction/stage0/Stage0Test.java
@@ -1,8 +1,8 @@
 package transaction.stage0;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * ACID 기본 원칙이 무엇인지 학습해보자.
@@ -10,6 +10,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 예) final var answer = "database";
  *
  * ACID
+ * Atomicity
+ * Consistency
+ * Isolation
+ * Durability
  * https://en.wikipedia.org/wiki/ACID
  *
  * Database Basics: ACID Transactions
@@ -20,7 +24,7 @@ class Stage0Test {
     // 동시에 실행되는 트랜잭션이 서로에게 영향을 미치지 못하도록 보장하는 트랜잭션의 특성은?
     @Test
     void quiz1() {
-        final var answer = "";
+        final var answer = "isolation";
         assertThat(Sha256.encrypt(answer.toLowerCase()))
                 .isEqualTo("3624d3181d5c4f8abf2f25fa708f5efa04236b79d0deafe9f292b590b2ca0f7e");
     }
@@ -28,7 +32,7 @@ class Stage0Test {
     // 트랜잭션을 성공적으로 실행하면 그 결과가 항상 기록되어야 하는 트랜잭션의 특성은?
     @Test
     void quiz2() {
-        final var answer = "";
+        final var answer = "Durability";
         assertThat(Sha256.encrypt(answer.toLowerCase()))
                 .isEqualTo("2731dedfe254c1d83b35853d325b5218e66fead073a6abcfbe9f568c84d43473");
     }
@@ -36,7 +40,7 @@ class Stage0Test {
     // 트랜잭션이 성공적으로 완료하면 언제나 동일한 데이터베이스 상태로 유지하는 것을 의미하는 트랜잭션의 특성은?
     @Test
     void quiz3() {
-        final var answer = "";
+        final var answer = "consistency";
         assertThat(Sha256.encrypt(answer.toLowerCase()))
                 .isEqualTo("0d00a53b5550a5f409891471880956f3a4b060c31b7a73c15149e051e5c24ce5");
     }
@@ -44,7 +48,7 @@ class Stage0Test {
     // 트랜잭션이 완전히 성공하거나 완전히 실패하는 단일 단위로 처리되도록 보장하는 트랜잭션의 특성은?
     @Test
     void quiz4() {
-        final var answer = "";
+        final var answer = "atomicity";
         assertThat(Sha256.encrypt(answer.toLowerCase()))
                 .isEqualTo("3931c975909268ae950c3d126f70efd9158ed6168241ed66713a5ff47d7a2d4d");
     }

--- a/transaction/src/test/java/transaction/stage1/Stage1Test.java
+++ b/transaction/src/test/java/transaction/stage1/Stage1Test.java
@@ -1,7 +1,13 @@
 package transaction.stage1;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -12,13 +18,6 @@ import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 import transaction.DatabasePopulatorUtils;
 import transaction.RunnableWrapper;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 격리 레벨(Isolation Level)에 따라 여러 사용자가 동시에 db에 접근했을 때 어떤 문제가 발생하는지 확인해보자.
@@ -58,10 +57,10 @@ class Stage1Test {
      *   Read phenomena | Dirty reads
      * Isolation level  |
      * -----------------|-------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |   +
+     * Read Committed   |   -
+     * Repeatable Read  |   -
+     * Serializable     |   -
      */
     @Test
     void dirtyReading() throws SQLException {
@@ -81,7 +80,7 @@ class Stage1Test {
             final var subConnection = dataSource.getConnection();
 
             // 적절한 격리 레벨을 찾는다.
-            final int isolationLevel = Connection.TRANSACTION_NONE;
+            final int isolationLevel = Connection.TRANSACTION_READ_COMMITTED;
 
             // 트랜잭션 격리 레벨을 설정한다.
             subConnection.setTransactionIsolation(isolationLevel);
@@ -111,10 +110,10 @@ class Stage1Test {
      *   Read phenomena | Non-repeatable reads
      * Isolation level  |
      * -----------------|---------------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |   +
+     * Read Committed   |   + (?)
+     * Repeatable Read  |   -
+     * Serializable     |   -
      */
     @Test
     void noneRepeatable() throws SQLException {
@@ -130,7 +129,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_SERIALIZABLE;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -146,15 +145,15 @@ class Stage1Test {
             // 사용자A가 조회한 gugu 객체를 사용자B가 다시 조회했다.
             final var anotherUser = userDao.findByAccount(subConnection, "gugu");
 
-            // ❗사용자B가 gugu 객체의 비밀번호를 변경했다.(subConnection은 auto commit 상태)
+            // ❗사용자B가 gugu 객체의 비밀번호를 변경했다.(subConnection은 auto commit 상태) -> 아닌듯
             anotherUser.changePassword("qqqq");
-            userDao.update(subConnection, anotherUser);
+            userDao.update(subConnection, anotherUser); // commit 하는 것 같다.
         })).start();
 
         sleep(0.5);
 
         // 사용자A가 다시 gugu 객체를 조회했다.
-        // 사용자B는 패스워드를 변경하고 아직 커밋하지 않았다.
+        // 사용자B는 패스워드를 변경하고 아직 커밋하지 않았다. -> commit 했다..(?)
         final var actual = userDao.findByAccount(connection, "gugu");
 
         // 트랜잭션 격리 레벨에 따라 아래 테스트가 통과한다.
@@ -173,10 +172,10 @@ class Stage1Test {
      *   Read phenomena | Phantom reads
      * Isolation level  |
      * -----------------|--------------
-     * Read Uncommitted |
-     * Read Committed   |
-     * Repeatable Read  |
-     * Serializable     |
+     * Read Uncommitted |   +
+     * Read Committed   |   +
+     * Repeatable Read  |   +
+     * Serializable     |   -
      */
     @Test
     void phantomReading() throws SQLException {
@@ -197,7 +196,7 @@ class Stage1Test {
         connection.setAutoCommit(false);
 
         // 적절한 격리 레벨을 찾는다.
-        final int isolationLevel = Connection.TRANSACTION_NONE;
+        final int isolationLevel = Connection.TRANSACTION_SERIALIZABLE;
 
         // 트랜잭션 격리 레벨을 설정한다.
         connection.setTransactionIsolation(isolationLevel);
@@ -249,8 +248,8 @@ class Stage1Test {
     private static DataSource createH2DataSource() {
         final var jdbcDataSource = new JdbcDataSource();
         // h2 로그를 확인하고 싶을 때 사용
-//        jdbcDataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;TRACE_LEVEL_SYSTEM_OUT=3;MODE=MYSQL");
-        jdbcDataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=MYSQL;");
+        jdbcDataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;TRACE_LEVEL_SYSTEM_OUT=3;MODE=MYSQL");
+//        jdbcDataSource.setUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=MYSQL;");
         jdbcDataSource.setUser("sa");
         jdbcDataSource.setPassword("");
         return jdbcDataSource;

--- a/transaction/src/test/java/transaction/stage2/FirstUserService.java
+++ b/transaction/src/test/java/transaction/stage2/FirstUserService.java
@@ -66,7 +66,7 @@ public class FirstUserService {
         throw new RuntimeException();
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithSupports() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -77,7 +77,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-//    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithMandatory() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());
@@ -110,7 +110,7 @@ public class FirstUserService {
         return of(firstTransactionName, secondTransactionName);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+//    @Transactional(propagation = Propagation.REQUIRED)
     public Set<String> saveFirstTransactionWithNever() {
         final var firstTransactionName = TransactionSynchronizationManager.getCurrentTransactionName();
         userRepository.save(User.createTest());

--- a/transaction/src/test/java/transaction/stage2/SecondUserService.java
+++ b/transaction/src/test/java/transaction/stage2/SecondUserService.java
@@ -53,7 +53,7 @@ public class SecondUserService {
         return TransactionSynchronizationManager.getCurrentTransactionName();
     }
 
-    @Transactional(propagation = Propagation.NESTED)
+//    @Transactional(propagation = Propagation.NESTED)
     public String saveSecondTransactionWithNested() {
         userRepository.save(User.createTest());
         logActualTransactionActive();


### PR DESCRIPTION
# Transaction

### 격리레벨

트랜잭션이 얼마나 서로 독립적인지를 나타내는 개념

트랜잭션이 독립적이지 않으면 동시에 여러 클라이언트가 데이터에 접근하고 수정하기 때문에 비정상적인 현상이 나타날 수 있다.

### 트랜잭션의 속성

1. Atomicity (원자성)
    1. 모두 성공하거나 모두 실패해야한다.
2. Consistency (일관성)
    1. 트랜잭션 전후에는 데이터의 일관성이 손상되지 않아야 한다.
3. Isolation (격리성, 독립성)
    1. 동시에 실행하는 여러 개의 트랜잭션이 서로 영향을 주지 않아야 한다.
4. Durability (영속성, 지속성)
    1. 커밋이 완료된 트랜잭션은 손상되지 않아야 한다.

- 영속성 vs 일관성 ..?

일관성은 트랜잭션 도중에 데이터가 외부에 의해 변화되지 않는 것을 의미?

- ㄴㄴ
- 데이터베이스 상태에 대한 언급이다.
- 일관성을 위반하는 사례
    - “모든 고객은 반드시 이름을 가지고 있어야 한다.” 라는 데이터베이스 규약이 있을때
        - 이름없는 고객을 추가 → 일관성 위반
        - 기존 고객의 이름을 삭제 → 일관성 위반

### 비정상적인 현상의 종류

1. Dirty reads
    1. 다른 트랜잭션에 의해 수정됐지만 아직 커밋되지 않은 데이터를 읽는 것
    2. 다른 쪽에서 만약 커밋되지 않은 것을 읽었다가 그 쪽에서 롤백을 해버린다면?
2. Non-repeatable reads
    1. 같은 쿼리를 두번 실행했는데 그 사이에 다른 트랜잭션이 커밋해버려서 두 쿼리 결과가 다르게 나타나는 현상
3. Phantom reads
    1. 한 트랜잭션 내에서 같은 쿼리를 두 번 수행했는데, 첫 번째 쿼리에서 없던 유령(phantom)레코드가 두 번째 쿼리에서 나타나는 현상

### 격리레벨의 종류

1. Read Uncommitted
    1. 트랜잭션에서 처리 중인 커밋되지 않은 데이터를 다른 트랜잭션(Read Uncommitted 설정이 된)이 읽는 것을 허용
2. Read Commited
    1. 커밋이 되어 확정된 데이터만 트랜잭션(ReadCommitted가 설정된)이 읽도록 허용 → Dirty Read 방지
    2. 이래도 시점에 따라 Non-repeatable reads, Phantom reads 는 발생할 수 있다.
3. Repeatable Read
    1. 같은 쿼리를 두 번 이상 수행할 때 첫번째 쿼리에 있던 레코드가 사라지거나 바뀌는 현상을 방지해준다.
    2. 그런데 추가되는건(Phantom Read) 못막는다.
4. Serializable
    1. 쿼리를 두 번 이상 수행할 때 첫번째 레코드가 사라지거나 값이 바뀌지 않음은 물론 새로운 레코드가 나타나지도 않는다.

- 각 레벨을 보장하는 원리

### **트랜잭션 전파**

1. Required
    1. 외부 트랜잭션에 참여함
2. Requireds_new
    1. 독립적인 새로운 **물리적** 트랜잭션 생성
    2. 이 새로운 트랜잭션에서 롤백되면 이 트랜잭션만 롤백
3. nested
    1. 부모 트랜잭션이 존재하면 중첩 트랜잭션을 생성
    2. 중첩 트랜잭션에서 롤백하면 중첩 트랜잭션의 시작시점까지만 롤백됨 → 부모까지는 전파 x
    3. 커밋은 부모 트랜잭션 커밋때 같이됨
4. supports
    1. 트랜잭션이 존재하면 그걸 타고 아니면 안만듬
    2. 만약 열린 트랜잭션이 없다면 논리적 트랜잭션은 존재한다.
5. mandatory
    1. 트랜잭션이 존재하면 그걸 타고 아니면 예외터뜨림
6. not_supported
    1. 트랜잭션이 존재하면 일시중지(보류). 비트랜잭션으로 실행
    2. 만약 열린 트랜잭션이 없다면 논리적 트랜잭션은 존재한다.
    3. 일시중지, 보류의 뜻이 뭘까?
        1. 그냥 둔다. not supported 안에서 동작하는 애들은 비 트랜잭션으로 실행된다.
7. never
    1. 비 트랜잭션으로 실행하고 트랜잭션이 존재하면 예외

Required_new vs Nested

- 커밋시점이 다르다.
    - new : 새롭게 생긴 트랜잭션이 끝날때 커밋
    - nested : 부모와 같이 커밋
- 중첩 트랜잭션이 생기고 나서 부모 트랜잭션 안에서 다음 로직을 수행할 때 롤백이 발생하면
    - new : 상관없음. 이미 커밋했음
    - nested : 롤백됨

### 스프링 논리적 트랜잭션과 물리적 트랜잭션의 차이

- 물리적 트랜잭션 : DB의 한번의 연결을 열고 끊음 사이의 DB 작업
- 논리적 트랜잭션 :
    - 피 호출자 중에서 `requires_new` 만이 물리적 트랜잭션을 열고 나머지는 논리적 트랜잭션을 연다.

참고 : [https://cdmana.com/2021/12/202112311937023960.html](https://cdmana.com/2021/12/202112311937023960.html)

### JPA Hibernate 에서 지원하지 않는 전파

- nested
    - [https://stackoverflow.com/questions/37927208/nested-transaction-in-spring-app-with-jpa-postgres](https://stackoverflow.com/questions/37927208/nested-transaction-in-spring-app-with-jpa-postgres)
- 
    - 

## 미션 의문

- 트랜잭션 격리레벨은 각 트랜잭션마다 설정하는건가?
    - 데이터를 변경하는 트랜잭션에 거나?
- stage1에서 dirtyReading은 두번째 트랜잭션의 격리레벨을 설정했고 nonRepeatable()에서는 첫번째 트랜잭션의 격리레벨을 설정했는데 이유가 뭘까?
- stage1
    - nonRepeatable() 테스트인데.. 왜 dirtyRead를 테스트하는거지?
        - → 사실 commit되고 있을 듯.. 그러면 전부 말이 됨.
    - 정말 내 예측대로 dirtyRead 테스트코드라면 Committed일때는 테스트가 통과해야할텐데 통과하지 않음..